### PR TITLE
Setup automatic download of Win7 box at http://aka.ms/vagrant-win7-ie11

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,6 +21,7 @@ Clause 252.227-7014 (FEB 2012)
 Vagrant.configure(2) do |config|
  
   config.vm.box = "win7"
+  config.vm.box_url = "http://aka.ms/vagrant-win7-ie11"
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
   config.vm.boot_timeout = 1000


### PR DESCRIPTION
Before 
```
% vagrant up
In order to continue you need to have read the current Sysinternals Software License Terms, and the current NXLOG PUBLIC LICENSE, and agree to be bound by the terms and conditions therein. Do you agree [Y/n]: Y
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'win7' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'win7' (v0) for provider: virtualbox
    default: Downloading: win7
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

Couldn't open file /home/yoyo/projects/unfetter-analytic/windows-example/win7

```
After
```
% vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'win7' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'win7' (v0) for provider: virtualbox
    default: Downloading: http://aka.ms/vagrant-win7-ie11
==> default: Successfully added box 'win7' (v0) for 'virtualbox'!
==> default: Importing base box 'win7'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: unfetter_windows
...
```