### PR TITLE
Fix nxlog URL

### DIFF
--- a/scripts/download-files.ps1
+++ b/scripts/download-files.ps1
@@ -15,7 +15,7 @@ $NxLogMsi = $DestDir+"nxlog-ce-2.9.1504.msi"
 New-Item -Force -ItemType directory -Path $DestDir
 
 $SourceSysmon = "https://download.sysinternals.com/files/Sysmon.zip"
-$SourceNxLog = "https://nxlog.co/system/files/products/files/1/nxlog-ce-2.9.1716.msi"
+$SourceNxLog = "https://nxlog.co/system/files/products/files/348/nxlog-ce-2.9.1716.msi"
 
 $wc = New-Object System.Net.WebClient
 $wc.proxy = $proxy

--- a/scripts/download-files.ps1
+++ b/scripts/download-files.ps1
@@ -10,7 +10,7 @@ $DestDir = "c:\vagrant\resources\"
 $SysmonExe = $DestDir+"Sysmon.exe"
 $SysmonZip = $DestDir+"Sysmon.zip"
 
-$NxLogMsi = $DestDir+"nxlog-ce-2.9.1504.msi"
+$NxLogMsi = $DestDir+"nxlog-ce-2.9.1716.msi"
 
 New-Item -Force -ItemType directory -Path $DestDir
 


### PR DESCRIPTION
```
% vagrant up

Bringing machine 'default' up with 'virtualbox' provider...
==> default: Running provisioner: shell...
    default: Running: scripts/download-files.ps1 as c:\tmp\vagrant-shell.ps1
    default:     Directory: C:\vagrant
    default: Mode                LastWriteTime     Length Name                              
    default: ----                -------------     ------ ----                              
    default: d----        11/22/2017   1:55 PM            resources                         
    default:     Directory: C:\tmp
    default: Mode                LastWriteTime     Length Name                              
    default: ----                -------------     ------ ----                              
    default: d----        11/22/2017   1:56 PM            sysmon                            
    default: Exception calling "DownloadFile" with "2" argument(s): "The remote server retur
    default: ned an error: (404) Not Found."
    default: At C:\tmp\vagrant-shell.ps1:50 char:46
    default: + If ($FileExists -eq $False) {$wc.DownloadFile <<<< ($SourceNxLog, $NxLogMsi)}
    default:     + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    default:     + FullyQualifiedErrorId : DotNetMethodException


```